### PR TITLE
FIX - Clear animal field when open StaysView edition modal

### DIFF
--- a/src/modules/stays/views/StaysView.vue
+++ b/src/modules/stays/views/StaysView.vue
@@ -79,6 +79,7 @@ function openEditionModal(stay: Stay) {
   modalHeader.value = 'Editar estadia';
   selectedStay.value = stay;
   formModel.value = stay;
+  formModel.value.animal = undefined;
   formModel.value.start = stay.start ? new Date(stay.start) : undefined;
   formModel.value.end = stay.end ? new Date(stay.end) : undefined;
   modalVisible.value = true;


### PR DESCRIPTION
Esse PR limpa o Dropdown de animais antes de abrir o modal de edição em estadias, evitando a possibilidade de cadastro de um `INVALID OBJECT`.