### PR TITLE
FEAT - Handle animal delete exception (409)

### DIFF
--- a/src/modules/stable/state/animals.store.ts
+++ b/src/modules/stable/state/animals.store.ts
@@ -116,12 +116,20 @@ export const useAnimalsStore = defineStore('animals', () => {
         (animal) => animal.id !== animalId,
       );
     } catch (error) {
-      toastStore.show({
-        severity: 'error',
-        summary: 'Erro ao deletar animal',
-        detail:
-          'Ocorreu um problema ao deletar o animal. Tente novamente mais tarde ou contate o suporte caso o problema persista.',
-      });
+      if (error instanceof Error && error.message.endsWith('409')) {
+        toastStore.show({
+          severity: 'error',
+          summary: 'Erro ao deletar animal',
+          detail: 'O animal não pôde ser deletado pois está relacionado a outra(s) entidade(s).',
+        });
+      } else {
+        toastStore.show({
+          severity: 'error',
+          summary: 'Erro ao deletar animal',
+          detail:
+            'Ocorreu um problema ao deletar o animal. Tente novamente mais tarde ou contate o suporte caso o problema persista.',
+        });
+      }
     }
 
     state.value.isDeleting = false;

--- a/src/modules/stays/views/StaysView.vue
+++ b/src/modules/stays/views/StaysView.vue
@@ -79,6 +79,7 @@ function openEditionModal(stay: Stay) {
   modalHeader.value = 'Editar estadia';
   selectedStay.value = stay;
   formModel.value = stay;
+  formModel.value.animal = undefined;
   formModel.value.start = stay.start ? new Date(stay.start) : undefined;
   formModel.value.end = stay.end ? new Date(stay.end) : undefined;
   modalVisible.value = true;


### PR DESCRIPTION
Esse PR:
- Trata o erro `409` ao deletar animais com relações de DB ativas
- Limpa o Dropdown de animais antes de abrir o modal de edição em estadias, evitando a possibilidade de cadastro de um `INVALID OBJECT`